### PR TITLE
#12 reactive 방식으로 feign client 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,12 +25,18 @@ dependencyManagement {
 }
 
 dependencies {
-    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    //implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'com.playtika.reactivefeign:feign-reactor-webclient:1.0.45'
+    implementation 'com.playtika.reactivefeign:feign-reactor-spring-configuration:1.0.45'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.json:json:20180813'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'junit', module: 'junit'
     }

--- a/src/main/java/me/nexters/doctor24/Doctor24Application.java
+++ b/src/main/java/me/nexters/doctor24/Doctor24Application.java
@@ -2,9 +2,10 @@ package me.nexters.doctor24;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.openfeign.EnableFeignClients;
 
-@EnableFeignClients
+import reactivefeign.spring.config.EnableReactiveFeignClients;
+
+@EnableReactiveFeignClients
 @SpringBootApplication
 public class Doctor24Application {
 

--- a/src/main/java/me/nexters/doctor24/external/publicdata/invoker/HospitalInvoker.java
+++ b/src/main/java/me/nexters/doctor24/external/publicdata/invoker/HospitalInvoker.java
@@ -1,15 +1,17 @@
 package me.nexters.doctor24.external.publicdata.invoker;
 
-import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+
+import reactivefeign.spring.config.ReactiveFeignClient;
+import reactor.core.publisher.Mono;
 
 /**
  * @author manki.kim
  */
-@FeignClient(name = "hospital", url = "http://apis.data.go.kr/B552657")
+@ReactiveFeignClient(name = "hospital", url = "http://apis.data.go.kr/B552657")
 public interface HospitalInvoker {
 	@GetMapping("/HsptlAsembySearchService/getHsptlMdcncFullDown")
-	String getHospitals(@RequestParam String serviceKey,
-		@RequestParam int pageNo, @RequestParam int numOfRows);
+	Mono<String> getHospitals(@RequestParam("serviceKey") String serviceKey,
+		@RequestParam("pageNo") int pageNo, @RequestParam("numOfRows") int numOfRows);
 }

--- a/src/main/java/me/nexters/doctor24/external/publicdata/invoker/PublicdataInvoker.java
+++ b/src/main/java/me/nexters/doctor24/external/publicdata/invoker/PublicdataInvoker.java
@@ -33,7 +33,7 @@ public class PublicdataInvoker implements HospitalRepository {
 	@Override
 	public PageResponse<Hospital> getHospitalPage(PageRequest pageRequest) {
 		String xmlResult = hospitalInvoker.getHospitals(key, pageRequest.getPageSafety(),
-			pageRequest.getCount());
+			pageRequest.getCount()).block();
 		HospitalResponse response = toObjectFromResponse(xmlResult, HospitalResponse.class);
 
 		return PageResponse.of(response.getHospitals(), pageRequest);

--- a/src/test/java/me/nexters/doctor24/invoker/HospitalRepositoryTest.java
+++ b/src/test/java/me/nexters/doctor24/invoker/HospitalRepositoryTest.java
@@ -23,14 +23,14 @@ class HospitalRepositoryTest {
 	@Test
 	void 전국_병원_인덱스() {
 		PageResponse<Hospital> hospitalPage =
-			hospitalRepository.getHospitalPage(PageRequest.of(2, 2000));
-		assertThat(hospitalPage.getContents().size(), is(2000));
+			hospitalRepository.getHospitalPage(PageRequest.of(2, 100));
+		assertThat(hospitalPage.getContents().size(), is(100));
 	}
 
 	@Test
 	void 전체_조회_샘플() {
 		PageResponse<Hospital> hospitalPage =
-			hospitalRepository.getHospitalPage(PageRequest.of(1, 2000));
+			hospitalRepository.getHospitalPage(PageRequest.of(1, 100));
 		List<Hospital> hospitals = new ArrayList<>(hospitalPage.getContents());
 		while (hospitalPage.hasNext()) {
 			hospitalPage =


### PR DESCRIPTION
reactive 방식으로 feign client 기능일 제공 해주는 라이브러리가 있어서 이걸 쓰긴 했어

webclient 쪽 back pressure buffer size 제한 때문에 한 번에 max 200개씩 밖에 못 가져오네
이거는 우리 배치 돌릴때 고민 해봐야 될 것 같아 그만큼 네티워크 호출량이 많아 지니까
설정을 통해서 늘릴 수 있는 방안도 찾아봐야겠어

참고
https://github.com/spring-cloud/spring-cloud-openfeign/issues/4
https://github.com/Playtika/feign-reactive