### PR TITLE
#19 키 파일 분리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -278,3 +278,5 @@ gradle-app.setting
 # End of https://www.gitignore.io/api/vim,linux,macos,gradle,windows,eclipse,intellij+all,visualstudiocode
 
 **/node_modules
+
+application-key.yml

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,13 +1,10 @@
 spring:
   profiles:
     active: local
-    include: swagger, mongo, logging
+    include: swagger, mongo, logging, key
   batch:
     job:
       enabled: false
-
-hospital:
-  key: 9jkqLh1hLcKTDDzsOi%2FtwtxbpUBvzmE7TkZuW019x%2BvmUeAeU%2BBUqQMUfvu1QcBpo%2Bhr45T3s%2FysWNu%2FM6goLA%3D%3D
 
 server:
   port: 8080


### PR DESCRIPTION
spring cloud로 해볼라고 했는데 spring cloud 의 이점이 설정파일을 편하게 refresh 할 수 있는 점인데 우리가 키 파일을 바꿀 일이 없더라고. 키 하나 하루 요청허용이 백만건이라 교체할 일이 없을듯.
spring cloud 를 서버에 띄웠더니 기본적으로 램 15퍼는 먹는것 같음. (cpu2, ram4)
굳이 할 필요가 없다고 생각이 듬. 그래서 그냥 날림.
그래서 로컬에서는 application-key.yml 로 ignore 처리한 파일 너랑 나랑 들고있고 서버 스크립트 실행할 때 command-line으로 key 넣어서 실행하는게 좋아보임. 우리 앱서버 스크립트에 (server.sh) 키 넣어놓았음

resolves: #19

그냥 publicdata.key로 똑같이 바꿀까