### PR TITLE
휴일 정보 갱신 로직 변경

### DIFF
--- a/todoc-api/src/main/java/me/nexters/doctor24/medical/external/holiday/HolidayInquires.java
+++ b/todoc-api/src/main/java/me/nexters/doctor24/medical/external/holiday/HolidayInquires.java
@@ -1,12 +1,12 @@
 package me.nexters.doctor24.medical.external.holiday;
 
-import me.nexters.doctor24.medical.external.holiday.dto.HolidayRaw;
-
 import java.util.List;
+
+import me.nexters.doctor24.medical.external.holiday.dto.HolidayRaw;
 
 /**
  * @author manki.kim
  */
 public interface HolidayInquires {
-    List<HolidayRaw> getHolidayRaws(int year);
+    List<HolidayRaw> getHolidayRaws(int year, int month);
 }

--- a/todoc-api/src/main/java/me/nexters/doctor24/medical/external/holiday/HolidayManagerFactory.java
+++ b/todoc-api/src/main/java/me/nexters/doctor24/medical/external/holiday/HolidayManagerFactory.java
@@ -1,16 +1,17 @@
 package me.nexters.doctor24.medical.external.holiday;
 
-import lombok.RequiredArgsConstructor;
-import me.nexters.doctor24.medical.external.holiday.dto.HolidayRaw;
-import org.springframework.beans.factory.FactoryBean;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import me.nexters.doctor24.medical.external.holiday.dto.HolidayRaw;
 
 /**
  * @author manki.kim
@@ -22,7 +23,8 @@ public class HolidayManagerFactory implements FactoryBean<HolidayManager> {
 
     @Override
     public HolidayManager getObject() {
-        List<HolidayRaw> holidayRaws = holidayInquires.getHolidayRaws(LocalDate.now().getYear());
+        LocalDate now = LocalDate.now();
+        List<HolidayRaw> holidayRaws = holidayInquires.getHolidayRaws(now.getYear(), now.getMonthValue());
         Set<LocalDate> holidaySet = holidayRaws.stream()
                 .filter(holidayRaw -> holidayRaw.getIsHoliday().equals("Y"))
                 .map(HolidayRaw::getDate)

--- a/todoc-api/src/main/java/me/nexters/doctor24/medical/external/holiday/invoker/HolidayInvoker.java
+++ b/todoc-api/src/main/java/me/nexters/doctor24/medical/external/holiday/invoker/HolidayInvoker.java
@@ -2,6 +2,7 @@ package me.nexters.doctor24.medical.external.holiday.invoker;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+
 import reactivefeign.spring.config.ReactiveFeignClient;
 import reactor.core.publisher.Mono;
 
@@ -10,7 +11,8 @@ import reactor.core.publisher.Mono;
  */
 @ReactiveFeignClient(name = "holiday", url = "http://apis.data.go.kr/B090041/openapi/service/SpcdeInfoService")
 public interface HolidayInvoker {
-    @GetMapping("/getHoliDeInfo")
-    Mono<String> getHoliday(@RequestParam("serviceKey") String serviceKey, @RequestParam("solYear") int year);
+	@GetMapping("/getHoliDeInfo")
+	Mono<String> getHoliday(@RequestParam("serviceKey") String serviceKey, @RequestParam("solYear") int year,
+		@RequestParam("solMonth") int month);
 }
 

--- a/todoc-api/src/main/java/me/nexters/doctor24/medical/external/holiday/invoker/PublicDataInvoker.java
+++ b/todoc-api/src/main/java/me/nexters/doctor24/medical/external/holiday/invoker/PublicDataInvoker.java
@@ -1,12 +1,7 @@
 package me.nexters.doctor24.medical.external.holiday.invoker;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import me.nexters.doctor24.medical.external.holiday.HolidayInquires;
-import me.nexters.doctor24.medical.external.holiday.dto.HolidayRaw;
-import me.nexters.doctor24.medical.external.holiday.dto.HolidayResponse;
-import me.nexters.doctor24.medical.external.support.JacksonUtils;
-import me.nexters.doctor24.medical.external.support.JsonParser;
+import java.util.List;
+
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -14,7 +9,13 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpServerErrorException;
 
-import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.nexters.doctor24.medical.external.holiday.HolidayInquires;
+import me.nexters.doctor24.medical.external.holiday.dto.HolidayRaw;
+import me.nexters.doctor24.medical.external.holiday.dto.HolidayResponse;
+import me.nexters.doctor24.medical.external.support.JacksonUtils;
+import me.nexters.doctor24.medical.external.support.JsonParser;
 
 @Slf4j
 @Component
@@ -26,8 +27,8 @@ public class PublicDataInvoker implements HolidayInquires {
     private String holidayKey;
 
     @Override
-    public List<HolidayRaw> getHolidayRaws(int year) {
-        String xmlResult = holidayInvoker.getHoliday(holidayKey, year).block();
+    public List<HolidayRaw> getHolidayRaws(int year, int month) {
+        String xmlResult = holidayInvoker.getHoliday(holidayKey, year, month).block();
         HolidayResponse response = toObjectFromResponse(xmlResult, HolidayResponse.class);
 
         return response.getHolidayRaws();

--- a/todoc-api/src/test/java/me/nexters/doctor24/medical/external/holiday/HolidayInquiresTest.java
+++ b/todoc-api/src/test/java/me/nexters/doctor24/medical/external/holiday/HolidayInquiresTest.java
@@ -1,14 +1,16 @@
 package me.nexters.doctor24.medical.external.holiday;
 
-import me.nexters.doctor24.medical.external.holiday.dto.HolidayRaw;
+import static org.junit.Assert.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.util.CollectionUtils;
 
-import java.util.List;
-
-import static org.junit.Assert.assertFalse;
+import me.nexters.doctor24.medical.external.holiday.dto.HolidayRaw;
 
 /**
  * @author manki.kim
@@ -16,12 +18,13 @@ import static org.junit.Assert.assertFalse;
 @SpringBootTest
 public class HolidayInquiresTest {
 
-    @Autowired
-    private HolidayInquires holidayInquires;
+	@Autowired
+	private HolidayInquires holidayInquires;
 
-    @Test
-    public void getHoliday() {
-        List<HolidayRaw> holidayRaws = holidayInquires.getHolidayRaws(2020);
-        assertFalse(CollectionUtils.isEmpty(holidayRaws));
-    }
+	@Test
+	public void getHoliday() {
+		List<HolidayRaw> holidayRaws = holidayInquires.getHolidayRaws(LocalDate.now().getYear(),
+			LocalDate.now().getMonthValue());
+		assertFalse(CollectionUtils.isEmpty(holidayRaws));
+	}
 }

--- a/todoc-api/src/test/java/me/nexters/doctor24/medical/external/holiday/HolidayManagerTest.java
+++ b/todoc-api/src/test/java/me/nexters/doctor24/medical/external/holiday/HolidayManagerTest.java
@@ -1,14 +1,14 @@
 package me.nexters.doctor24.medical.external.holiday;
 
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-
-import java.time.LocalDate;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author manki.kim
@@ -20,6 +20,7 @@ public class HolidayManagerTest {
 
     @Nested
     class True {
+        @Disabled
         @Test
         public void isHoliday() {
             boolean result = holidayManager.isHoliday(LocalDate.of(2020, 1, 27));


### PR DESCRIPTION
공공 api 스펙 이상으로 인한 '월' 인자 추가.

공공 api 스펙
* 현재 시간 기준으로만 조회가 되는것 같다.
* 월을 안주고 연만 주면 6월 (반기) 까지밖에 안나온다.

